### PR TITLE
Python 3 compatibility.

### DIFF
--- a/json_views/views.py
+++ b/json_views/views.py
@@ -21,7 +21,7 @@ from django.views.generic import View
 from django.views.generic.detail import BaseDetailView
 from django.views.generic.list import BaseListView
 from django.views.generic.edit import BaseFormView
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_text
 from django.db.models.base import ModelBase
 from django.db.models import ManyToManyField
 from django.http import HttpResponseNotAllowed, HttpResponse
@@ -31,6 +31,8 @@ try:
     import json
 except ImportError:
     from django.utils import simplejson as json
+
+from six import iteritems
 
 ##########################################################################
 ## JSON serialization helpers
@@ -45,7 +47,6 @@ def dumps(content, **json_opts):
     opts = {
         'ensure_ascii': False,
         'cls': LazyJSONEncoder,
-        'encoding': 'utf-8',
     }
 
     opts.update(json_opts)
@@ -77,7 +78,7 @@ class LazyJSONEncoder(json.JSONEncoder):
 
         # Other Python Types:
         try:
-            return force_unicode(obj)
+            return force_text(obj)
         except Exception:
             pass
 
@@ -183,7 +184,7 @@ class JSONDetailView(JSONResponseMixin, BaseDetailView):
         The development version has a QuerySet.dict method-- but not 1.3, so
         we have to do this manually until the new version comes out.
         """
-        querydict = dict([(k, v) for k, v in request.GET.iteritems()])
+        querydict = dict([(k, v) for k, v in iteritems(request.GET)])
         self.kwargs.update(querydict)
         kwargs.update(querydict)
         return super(JSONDetailView, self).get(request, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Requirements for json_views
 Django>=1.5
+six==1.10
 
 # Requirements for testing
 #nose==1.3.4


### PR DESCRIPTION
I'm in the process of converting a Python 2 project that includes _django-generic-json-views_ to Python 3. So I made a few compatibility fixes. 

I also tried to make the tests pass, but `test_dumps` and `test_dumps_opts` are failing currently because the key order of the `json.dumps()` output seems to have changed from Python 2 to 3. I don't know how these tests could be implemented so they pass in 2 and 3. If you have any idea please let me know and I'll try to adjust them.